### PR TITLE
Fix crash when filtering with regexp characters

### DIFF
--- a/src/renderer/Components/LocationsTab.tsx
+++ b/src/renderer/Components/LocationsTab.tsx
@@ -351,12 +351,10 @@ const LocationsTab = (): ReactElement => {
                                 } else val = val.replaceAll(window.path.sep, "");
                             }
 
-                            val = val.replaceAll("[", "\\[");
-                            val = val.replaceAll("]", "\\]");
-                            val = val.replaceAll("(", "\\(");
-                            val = val.replaceAll(")", "\\)");
-                            val = val.replaceAll("*", "\\-");
-                            val = val.replaceAll("+", "\\+");
+                            const mustEscape = "[]()*+";
+                            for (let c of mustEscape)
+                                val = val.replaceAll(c, "\\" + c);
+                            val = val.replaceAll('*', '-');
 
                             let filter = "";
                             if (['"', "`", "'"].includes(val[0])) {
@@ -367,7 +365,11 @@ const LocationsTab = (): ReactElement => {
                                         filter += window.path.sep;
                                         continue;
                                     }
-                                    filter += val[i] + ".*";
+                                    // avoid unescaping regexp characters
+                                    if (val[i] === '\\' && i + 1 < val.length && mustEscape.includes(val[i + 1]))
+                                        filter += val[i];
+                                    else
+                                        filter += val[i] + ".*";
                                 }
                             setFocused(-1);
                             setFilter(filter);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](../docs/contribute.md) for this project.
- [x] I agree to follow the [code of conduct](../CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The changes does not disrupt the app in other supported OS.

**Summarize your changes:**
Typing a `(` in search would crash the main thread (due to an unclosed group), as the `\` used to escape it was separated by a `.*`. Fix that.