### PR TITLE
Support dash as delimiter in chapter names

### DIFF
--- a/src/renderer/Components/Reader.tsx
+++ b/src/renderer/Components/Reader.tsx
@@ -31,11 +31,12 @@ const processChapterNumber = (chapterName: string): number | undefined => {
     ep 1
     ep1
     uploader_ch.1
+    uploader-ch.1
 
     support float chapter number
-    /(^| |\.|_)((chapter|(c(h)?)|(p(t)?(art)?)|(ep(isode)?))((\s)?(-|_|\.)?(\s)?)?(?<main>\d+(\.\d+)?))/gi;
+    /(^| |\.|_|-)((chapter|(c(h)?)|(p(t)?(art)?)|(ep(isode)?))((\s)?(-|_|\.)?(\s)?)?(?<main>\d+(\.\d+)?))/gi;
      */
-    const regex = /(^| |\.|_)((chapter|(c(h)?)|(p(t)?(art)?)|(ep(isode)?))((\s)?(-|_|\.)?(\s)?)?(?<main>\d+))/gi;
+    const regex = /(^| |\.|_|-)((chapter|(c(h)?)|(p(t)?(art)?)|(ep(isode)?))((\s)?(-|_|\.)?(\s)?)?(?<main>\d+))/gi;
     const results = [...chapterName.matchAll(regex)];
     if (results.length === 0) return;
     const result = results[0].groups?.main;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](../docs/contribute.md) for this project.
- [x] I agree to follow the [code of conduct](../CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The changes does not disrupt the app in other supported OS.

**Summarize your changes:**
Extended the chapter detection regex to support `-` as a valid delimiter before the "chapter <number>" part.

**Context:**
Currently `_` is already supported and an example of `uploader_ch.1` is given. However i find that `-` is as legimitate as the underscore as a separator. We could have `uploader-ch.1` (or even `uploader-name-ch.1`).

In my case I have a slightly different format, `<index>-Chapter <chapter number>`, which allows me to handle "special chapters" or "announcements" while still retaining the correct order. Example : 

* 0011-Chapter 11
* 0012-Chapter 12
* 0013-Chapter 12.5
* 0014-Chapter 13

I'd simply like to keep `-` as a separator instead of switching to `_`.