### PR TITLE
feat: add rpm to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,19 @@ jobs:
                   node-version: 18.15.0
                   cache: pnpm
 
+            - name: Install rpm for package creation
+              run: |
+                sudo apt-get update
+                sudo apt-get install -y rpm
+
             - name: Install dependencies
               run: pnpm install
 
             - name: forge make deb
               run: pnpm make:deb
+
+            - name: forge make rpm
+              run: pnpm make:rpm
 
             - name: Set version
               id: version

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "make:win32": "electron-forge make --targets=@electron-forge/maker-squirrel,@electron-forge/maker-zip --arch=ia32",
         "make:win64": "electron-forge make --targets=@electron-forge/maker-squirrel,@electron-forge/maker-zip --arch=x64",
         "make:deb": "electron-forge make --targets=@electron-forge/maker-deb",
+        "make:rpm": "electron-forge make --targets=@electron-forge/maker-rpm",
         "release": "node tagAndPush.js"
     },
     "license": "MIT",


### PR DESCRIPTION
- [x] I have read the [contribution documentation](../docs/contribute.md) for this project.
- [x] I agree to follow the [code of conduct](../CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The changes does not disrupt the app in other supported OS.

**Summarize your changes:**

This adds RPM package build to the build process as this is not part of the releases ATM.

On Fedora, the resulting archive can be installed and the executable works. The CLI output has vsync error logs that do not appear to affect functionnality:

```
[119716:0211/210732.314857:ERROR:gl_surface_presentation_helper.cc(260)] GetVSyncParametersIfAvailable() failed for 1 times!
[119716:0211/210732.316216:ERROR:gl_surface_presentation_helper.cc(260)] GetVSyncParametersIfAvailable() failed for 2 times!
[119716:0211/210735.532459:ERROR:gl_surface_presentation_helper.cc(260)] GetVSyncParametersIfAvailable() failed for 3 times!
```
