### PR TITLE
fix: chapter list not refreshing after mark read/unread

### DIFF
--- a/src/renderer/store/reader.ts
+++ b/src/renderer/store/reader.ts
@@ -1,6 +1,7 @@
 import type { LibraryItemWithProgress } from "@common/types/db";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { RootState } from ".";
+import { updateChaptersRead, updateChaptersReadAll } from "./library";
 
 // ! ReaderState.content.progress is not linked to libraryItem.progress
 // ! both are independent to prevent issues with multiple windows
@@ -145,6 +146,27 @@ const readerSlice = createSlice({
                 state.content.progress.chapterName = chapterName || state.content.progress.chapterName;
             }
         },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(updateChaptersRead.fulfilled, (state, action) => {
+                if (
+                    state.type === "manga" &&
+                    state.content?.progress &&
+                    state.content.link === action.payload.itemLink
+                ) {
+                    state.content.progress.chaptersRead = action.payload.chapterRead;
+                }
+            })
+            .addCase(updateChaptersReadAll.fulfilled, (state, action) => {
+                if (
+                    state.type === "manga" &&
+                    state.content?.progress &&
+                    state.content.link === action.payload.itemLink
+                ) {
+                    state.content.progress.chaptersRead = action.payload.chaptersRead;
+                }
+            });
     },
 });
 


### PR DESCRIPTION
- [x] I have read the [contribution documentation](../docs/contribute.md) for this project.
- [x] I agree to follow the [code of conduct](../CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The changes does not disrupt the app in other supported OS.

**Summarize your changes:**

Fixes #486

The chapter list sidebar was not visually updating after marking a chapter as read or unread via the context menu.

**Root cause:** The `updateChaptersRead` and `updateChaptersReadAll` thunks correctly update the database and the library store, but `reader.content.progress.chaptersRead` (used by `ReaderSideList` to determine `inHistory` highlighting) was never synced back into the reader slice.

**Fix:** Added `addMatcher` cases in `reader.ts` listening on `library/updateChaptersRead/fulfilled` and `library/updateChaptersReadAll/fulfilled` action types. When either thunk resolves, `chaptersRead` in the reader state is updated immediately. Action type strings are used instead of imported thunk creators to avoid a circular import through `store/index.ts`.