### PR TITLE
fix: scope CSS rules inside @media blocks for epub reader

### DIFF
--- a/src/renderer/features/reader/epub/StyleSheets.tsx
+++ b/src/renderer/features/reader/epub/StyleSheets.tsx
@@ -25,20 +25,24 @@ const StyleSheets = memo(
                                             .replaceAll("\\", "/")}"`,
                                     );
                                 });
-                                // to make sure styles don't apply outside
-                                // todo, can use scope in latest version of electron
-                                const ast = css.parse(txt);
-                                const scopeRule = (e: css.Node) => {
-                                    if (e.type === "rule") {
-                                        (e as css.Rule).selectors = (e as css.Rule).selectors?.map((s) =>
-                                            s.includes("section.main") ? s : `#EPubReader section.main ${s}`,
-                                        );
-                                    } else if (e.type === "media") {
-                                        (e as css.Media).rules?.forEach(scopeRule);
-                                    }
-                                };
-                                ast.stylesheet?.rules.forEach(scopeRule);
-                                txt = css.stringify(ast);
+                                try {
+                                    // to make sure styles don't apply outside
+                                    // todo, can use scope in latest version of electron
+                                    const ast = css.parse(txt);
+                                    const scopeRule = (e: css.Node) => {
+                                        if (e.type === "rule") {
+                                            (e as css.Rule).selectors = (e as css.Rule).selectors?.map((s) =>
+                                                s.includes("section.main") ? s : `#EPubReader section.main ${s}`,
+                                            );
+                                        } else if (e.type === "media") {
+                                            (e as css.Media).rules?.forEach(scopeRule);
+                                        }
+                                    };
+                                    ast.stylesheet?.rules.forEach(scopeRule);
+                                    txt = css.stringify(ast);
+                                } catch (e) {
+                                    window.logger.warn("Failed to scope stylesheet, using raw content.", e);
+                                }
                                 stylesheet.innerHTML = txt;
                                 node.appendChild(stylesheet);
                             } catch (e) {

--- a/src/renderer/features/reader/epub/StyleSheets.tsx
+++ b/src/renderer/features/reader/epub/StyleSheets.tsx
@@ -28,13 +28,16 @@ const StyleSheets = memo(
                                 // to make sure styles don't apply outside
                                 // todo, can use scope in latest version of electron
                                 const ast = css.parse(txt);
-                                ast.stylesheet?.rules.forEach((e) => {
+                                const scopeRule = (e: css.Node) => {
                                     if (e.type === "rule") {
-                                        (e as css.Rule).selectors = (e as css.Rule).selectors?.map((e) =>
-                                            e.includes("section.main") ? e : `#EPubReader section.main ${e}`,
+                                        (e as css.Rule).selectors = (e as css.Rule).selectors?.map((s) =>
+                                            s.includes("section.main") ? s : `#EPubReader section.main ${s}`,
                                         );
+                                    } else if (e.type === "media") {
+                                        (e as css.Media).rules?.forEach(scopeRule);
                                     }
-                                });
+                                };
+                                ast.stylesheet?.rules.forEach(scopeRule);
                                 txt = css.stringify(ast);
                                 stylesheet.innerHTML = txt;
                                 node.appendChild(stylesheet);


### PR DESCRIPTION
Fixes #488

The CSS scoping function only processed top-level rules in the stylesheet AST. Rules nested inside `@media` blocks were skipped entirely, so any table styles written inside a media query were not scoped to `#EPubReader section.main` and failed to apply.

Refactored the scoping logic into a recursive `scopeRule` function that traverses into `@media` (and any other nested rule containers). Also fixed a variable shadowing bug in the inner `.map()` callback while here.

Let me know if this looks good, happy to contribute.