### PR TITLE
fix: disable performance-heavy options by default

### DIFF
--- a/src/renderer/utils/readerSettingsSchema.ts
+++ b/src/renderer/utils/readerSettingsSchema.ts
@@ -132,10 +132,10 @@ export type MangaReaderSettings = z.infer<typeof mangaReaderSettingsSchema>;
 
 export const defaultMangaReaderSettings: MangaReaderSettings = {
     readerWidth: 60,
-    variableImageSize: true,
+    variableImageSize: false,
     readerTypeSelected: 0,
     pagesPerRowSelected: 0,
-    gapBetweenRows: true,
+    gapBetweenRows: false,
     sideListWidth: 450,
     widthClamped: true,
     gapSize: 10,
@@ -182,7 +182,7 @@ export const defaultMangaReaderSettings: MangaReaderSettings = {
         customColorFilter: true,
         others: false,
     },
-    focusChapterInList: true,
+    focusChapterInList: false,
     hideSideList: false,
     autoUpdateAnilistProgress: false,
     enableTouchScroll: false,
@@ -352,7 +352,7 @@ export const defaultBookReaderSettings: BookReaderSettings = {
     },
     quickFontFamily: ["Roboto", "Cambria"],
     textSelect: true,
-    focusChapterInList: true,
+    focusChapterInList: false,
     hideSideList: false,
     backgroundImage: {
         enabled: false,


### PR DESCRIPTION
variableImageSize, gapBetweenRows, and focusChapterInList were all enabled by default, causing performance issues for users on lower-end hardware without them realizing it.

Changed all three defaults to false.

Closes #439